### PR TITLE
refactor(visual-vocab): rename GROUNDED gauge state to TAXIING

### DIFF
--- a/commands/ship.md
+++ b/commands/ship.md
@@ -19,7 +19,7 @@ Four semantic states expressed as fixed-width 10-block bars. Use these consisten
 ```
   ██████████  LANDED       complete, healthy
   ██████░░░░  IN FLIGHT    work in progress
-  ░░░░░░░░░░  GROUNDED     waiting, not started
+  ░░░░░░░░░░  TAXIING     waiting, not started
   ░░░░!!░░░░  FAULT        failed, needs attention
 ```
 
@@ -318,7 +318,7 @@ Landing card rules:
 - **Branch** shows source arrow target (e.g., `feature/oauth-refresh → develop`).
 - **Cargo** shows total commit count and files changed across those commits.
 - **Pipeline gauges** show one row per step actually performed. If a commit was skipped (nothing to commit), omit the Commit row. Use FAULT state if any step failed.
-- If PR creation was skipped (unknown host), replace the PR gauge row with `PR      ░░░░░░░░░░  GROUNDED  (manual)` and include the push URL instead.
+- If PR creation was skipped (unknown host), replace the PR gauge row with `PR      ░░░░░░░░░░  TAXIING  (manual)` and include the push URL instead.
 
 After the card, append two actionable follow-up lines:
 

--- a/commands/squadron.md
+++ b/commands/squadron.md
@@ -70,7 +70,7 @@ Four semantic states expressed as fixed-width 10-block bars. Use these consisten
 ```
   ██████████  LANDED       complete, healthy
   ██████░░░░  IN FLIGHT    work in progress
-  ░░░░░░░░░░  GROUNDED     waiting, not started
+  ░░░░░░░░░░  TAXIING     waiting, not started
   ░░░░!!░░░░  FAULT        failed, needs attention
 ```
 
@@ -82,7 +82,7 @@ Gauge usage rules:
 Squadron has its own visual vocabulary (mission cards, scorecards, tension diagrams, consensus markers) defined in the squadron command. This partial provides only the gauge states above for reuse. Do not duplicate squadron-specific visual elements here.
 
 
-Gauge states (LANDED, IN FLIGHT, GROUNDED, FAULT) are defined in the shared visual-vocabulary partial above. Squadron uses these for cross-command consistency but relies on its own visual vocabulary below for mission cards, scorecards, tension diagrams, and consensus markers.
+Gauge states (LANDED, IN FLIGHT, TAXIING, FAULT) are defined in the shared visual-vocabulary partial above. Squadron uses these for cross-command consistency but relies on its own visual vocabulary below for mission cards, scorecards, tension diagrams, and consensus markers.
 
 Three visual registers govern all output formatting:
 

--- a/commands/takeoff.md
+++ b/commands/takeoff.md
@@ -113,7 +113,7 @@ Four semantic states expressed as fixed-width 10-block bars. Use these consisten
 ```
   ██████████  LANDED       complete, healthy
   ██████░░░░  IN FLIGHT    work in progress
-  ░░░░░░░░░░  GROUNDED     waiting, not started
+  ░░░░░░░░░░  TAXIING     waiting, not started
   ░░░░!!░░░░  FAULT        failed, needs attention
 ```
 
@@ -134,7 +134,7 @@ Render before work begins. Shows the mission parameters the command will execute
   Worktree:   [worktree-path]
   Units:      [N work units planned]
   Strategy:   [execution strategy]
-  ░░░░░░░░░░  GROUNDED
+  ░░░░░░░░░░  TAXIING
 ```
 
 ### Gate Panel
@@ -146,13 +146,13 @@ Render after each quality gate completes. Shows gate results inline.
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   test-runner       ██████████  LANDED
   code-reviewer     ██████░░░░  IN FLIGHT
-  security-auditor  ░░░░░░░░░░  GROUNDED
+  security-auditor  ░░░░░░░░░░  TAXIING
 ```
 
 Gate panel rules:
 - One row per gate agent.
 - Gate name left-aligned, gauge bar right of name, state label after bar.
-- Update rows as gates complete -- replace GROUNDED with LANDED or FAULT.
+- Update rows as gates complete -- replace TAXIING with LANDED or FAULT.
 
 
 ## Input Processing
@@ -344,7 +344,7 @@ Use the Preflight Card template from the Visual Vocabulary above. Populate it wi
 - **Units**: count of non-closed work units from the plan
 - **Strategy**: the selected execution strategy (very_small_direct, medium_single_branch, or large_multi_worktree)
 
-The card ends with the `GROUNDED` gauge, indicating work has not yet started.
+The card ends with the `TAXIING` gauge, indicating work has not yet started.
 
 ## Strategy Execution
 
@@ -405,7 +405,7 @@ From the coding agent's `files_modified` list, classify each file into a work ty
 - If no pattern matches, default to `application_code`
 
 ### Step 3: Echo Selection
-Before deploying gate agents, announce the selection and render an initial Gate Panel with all gates in `GROUNDED` state:
+Before deploying gate agents, announce the selection and render an initial Gate Panel with all gates in `TAXIING` state:
 "Selected gate profile: [work_type]. Running [N] gate agents: [agent list]."
 For union profiles: "Mixed changeset detected ([types]). Union profile: Gate 1 [agents], Gate 2 [agents]."
 

--- a/scripts/contracts.test.js
+++ b/scripts/contracts.test.js
@@ -527,7 +527,7 @@ const VISUAL_VOCAB_COMMANDS = ['takeoff', 'ship', 'status-worktrees', 'squadron'
 /**
  * The four canonical gauge state labels from the visual-vocabulary partial.
  */
-const GAUGE_STATES = ['LANDED', 'IN FLIGHT', 'GROUNDED', 'FAULT'];
+const GAUGE_STATES = ['LANDED', 'IN FLIGHT', 'TAXIING', 'FAULT'];
 
 describe('Contract: command files contain visual vocabulary gauge states', () => {
   assert.ok(

--- a/scripts/visual-vocabulary.test.js
+++ b/scripts/visual-vocabulary.test.js
@@ -92,8 +92,8 @@ describe('visual-vocabulary gauge states', () => {
         `Missing IN FLIGHT state in ${context}`
       );
       assert.ok(
-        result.includes('GROUNDED'),
-        `Missing GROUNDED state in ${context}`
+        result.includes('TAXIING'),
+        `Missing TAXIING state in ${context}`
       );
       assert.ok(result.includes('FAULT'), `Missing FAULT state in ${context}`);
     });

--- a/src/commands/ship.ejs
+++ b/src/commands/ship.ejs
@@ -271,7 +271,7 @@ Landing card rules:
 - **Branch** shows source arrow target (e.g., `feature/oauth-refresh → develop`).
 - **Cargo** shows total commit count and files changed across those commits.
 - **Pipeline gauges** show one row per step actually performed. If a commit was skipped (nothing to commit), omit the Commit row. Use FAULT state if any step failed.
-- If PR creation was skipped (unknown host), replace the PR gauge row with `PR      ░░░░░░░░░░  GROUNDED  (manual)` and include the push URL instead.
+- If PR creation was skipped (unknown host), replace the PR gauge row with `PR      ░░░░░░░░░░  TAXIING  (manual)` and include the push URL instead.
 
 After the card, append two actionable follow-up lines:
 

--- a/src/commands/squadron.ejs
+++ b/src/commands/squadron.ejs
@@ -59,7 +59,7 @@ Error handling cycles (retries, over-length compression) do not change task stat
 
 <%- include('partials/visual-vocabulary', { context: 'squadron' }) %>
 
-Gauge states (LANDED, IN FLIGHT, GROUNDED, FAULT) are defined in the shared visual-vocabulary partial above. Squadron uses these for cross-command consistency but relies on its own visual vocabulary below for mission cards, scorecards, tension diagrams, and consensus markers.
+Gauge states (LANDED, IN FLIGHT, TAXIING, FAULT) are defined in the shared visual-vocabulary partial above. Squadron uses these for cross-command consistency but relies on its own visual vocabulary below for mission cards, scorecards, tension diagrams, and consensus markers.
 
 Three visual registers govern all output formatting:
 

--- a/src/commands/status-worktrees.ejs
+++ b/src/commands/status-worktrees.ejs
@@ -44,7 +44,7 @@ Collect status for every worktree first, then render the fleet dashboard, then r
 #
 #   LANDED    — RESULTS.md exists and no test failures detected
 #   IN FLIGHT — Work has started (has commits beyond branch point, or TASK.md exists, or uncommitted changes)
-#   GROUNDED  — Worktree exists but no work started (clean, no TASK.md, no commits beyond branch point)
+#   TAXIING  — Worktree exists but no work started (clean, no TASK.md, no commits beyond branch point)
 #   FAULT     — A quality gate failed (test-runner, code-reviewer, or security-auditor logged a failure)
 #
 # Gate progress is tracked by counting completed quality gates:
@@ -63,12 +63,12 @@ declare -a FLEET_DETAILS=()
 determine_fleet_state() {
   local worktree_path="$1"
   local worktree_name=$(basename "$worktree_path")
-  local state="GROUNDED"
+  local state="TAXIING"
   local gates_passed=0
   local total_gates=3
 
   if [ ! -d "$worktree_path" ]; then
-    echo "GROUNDED|0/${total_gates} gates"
+    echo "TAXIING|0/${total_gates} gates"
     return
   fi
 
@@ -126,7 +126,7 @@ determine_fleet_state() {
       if [ "$commit_count" -gt 0 ]; then
         state="IN FLIGHT"
       else
-        state="GROUNDED"
+        state="TAXIING"
       fi
     fi
   fi
@@ -141,7 +141,7 @@ render_gauge() {
   case "$state" in
     "LANDED")    echo "██████████" ;;
     "IN FLIGHT") echo "██████░░░░" ;;
-    "GROUNDED")  echo "░░░░░░░░░░" ;;
+    "TAXIING")  echo "░░░░░░░░░░" ;;
     "FAULT")     echo "░░░░!!░░░░" ;;
     *)           echo "░░░░░░░░░░" ;;
   esac
@@ -176,7 +176,7 @@ fi
 # ── Collect fleet state for each worktree ─────────────
 declare -a SORTED_FAULT=()
 declare -a SORTED_INFLIGHT=()
-declare -a SORTED_GROUNDED=()
+declare -a SORTED_TAXIING=()
 declare -a SORTED_LANDED=()
 
 for worktree in "${WORKTREE_LIST[@]}"; do
@@ -190,13 +190,13 @@ for worktree in "${WORKTREE_LIST[@]}"; do
   case "$state" in
     "FAULT")     SORTED_FAULT+=("$entry") ;;
     "IN FLIGHT") SORTED_INFLIGHT+=("$entry") ;;
-    "GROUNDED")  SORTED_GROUNDED+=("$entry") ;;
+    "TAXIING")  SORTED_TAXIING+=("$entry") ;;
     "LANDED")    SORTED_LANDED+=("$entry") ;;
   esac
 done
 
-# Merge sorted arrays: FAULT first, then IN FLIGHT, GROUNDED, LANDED
-SORTED_FLEET=("${SORTED_FAULT[@]}" "${SORTED_INFLIGHT[@]}" "${SORTED_GROUNDED[@]}" "${SORTED_LANDED[@]}")
+# Merge sorted arrays: FAULT first, then IN FLIGHT, TAXIING, LANDED
+SORTED_FLEET=("${SORTED_FAULT[@]}" "${SORTED_INFLIGHT[@]}" "${SORTED_TAXIING[@]}" "${SORTED_LANDED[@]}")
 
 # ── Render Fleet Dashboard ────────────────────────────
 echo ""
@@ -216,7 +216,7 @@ done
 # ── Fleet Summary Footer ─────────────────────────────
 count_landed=${#SORTED_LANDED[@]}
 count_inflight=${#SORTED_INFLIGHT[@]}
-count_grounded=${#SORTED_GROUNDED[@]}
+count_taxiing=${#SORTED_TAXIING[@]}
 count_fault=${#SORTED_FAULT[@]}
 count_total=${#SORTED_FLEET[@]}
 
@@ -224,7 +224,7 @@ echo ""
 printf "  Fleet: %d worktrees" "$count_total"
 [ "$count_landed" -gt 0 ]   && printf "   %d landed" "$count_landed"
 [ "$count_inflight" -gt 0 ] && printf "   %d in flight" "$count_inflight"
-[ "$count_grounded" -gt 0 ] && printf "   %d grounded" "$count_grounded"
+[ "$count_taxiing" -gt 0 ] && printf "   %d taxiing" "$count_taxiing"
 [ "$count_fault" -gt 0 ]    && printf "   %d fault" "$count_fault"
 echo ""
 
@@ -394,7 +394,7 @@ The fleet dashboard renders a scannable overview before detailed information:
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   reaper-44-cache           ░░░░!!░░░░  FAULT      0/3 gates
   reaper-42-auth            ██████░░░░  IN FLIGHT  1/3 gates
-  reaper-43-migration       ░░░░░░░░░░  GROUNDED   0/3 gates
+  reaper-43-migration       ░░░░░░░░░░  TAXIING   0/3 gates
   reaper-41-billing         ██████████  LANDED     3/3 gates
 
   Fleet: 4 worktrees   1 landed   1 in flight   1 grounded   1 fault
@@ -408,5 +408,5 @@ States map to the Visual Vocabulary gauge bars:
 
 - `LANDED` -- Complete, all gates passed. Gauge: `██████████`
 - `IN FLIGHT` -- Work in progress (has commits, TASK.md, or uncommitted changes). Gauge: `██████░░░░`
-- `GROUNDED` -- Worktree exists but no work started. Gauge: `░░░░░░░░░░`
+- `TAXIING` -- Worktree exists but no work started. Gauge: `░░░░░░░░░░`
 - `FAULT` -- A quality gate failed or failure markers detected. Gauge: `░░░░!!░░░░`

--- a/src/commands/takeoff.ejs
+++ b/src/commands/takeoff.ejs
@@ -124,7 +124,7 @@ Use the Preflight Card template from the Visual Vocabulary above. Populate it wi
 - **Units**: count of non-closed work units from the plan
 - **Strategy**: the selected execution strategy (very_small_direct, medium_single_branch, or large_multi_worktree)
 
-The card ends with the `GROUNDED` gauge, indicating work has not yet started.
+The card ends with the `TAXIING` gauge, indicating work has not yet started.
 
 ## Strategy Execution
 
@@ -185,7 +185,7 @@ From the coding agent's `files_modified` list, classify each file into a work ty
 - If no pattern matches, default to `application_code`
 
 ### Step 3: Echo Selection
-Before deploying gate agents, announce the selection and render an initial Gate Panel with all gates in `GROUNDED` state:
+Before deploying gate agents, announce the selection and render an initial Gate Panel with all gates in `TAXIING` state:
 "Selected gate profile: [work_type]. Running [N] gate agents: [agent list]."
 For union profiles: "Mixed changeset detected ([types]). Union profile: Gate 1 [agents], Gate 2 [agents]."
 

--- a/src/partials/visual-vocabulary.ejs
+++ b/src/partials/visual-vocabulary.ejs
@@ -13,13 +13,13 @@ Status labels (plain text, no visual ornament):
 
 - **LANDED** -- complete, healthy
 - **IN FLIGHT** -- work in progress
-- **GROUNDED** -- waiting, not started
+- **TAXIING** -- waiting, not started
 - **FAULT** -- failed, needs attention
 <% } else { -%>
 ```
   ██████████  LANDED       complete, healthy
   ██████░░░░  IN FLIGHT    work in progress
-  ░░░░░░░░░░  GROUNDED     waiting, not started
+  ░░░░░░░░░░  TAXIING     waiting, not started
   ░░░░!!░░░░  FAULT        failed, needs attention
 ```
 
@@ -42,7 +42,7 @@ Render before work begins. Shows the mission parameters the command will execute
   Worktree:   [worktree-path]
   Units:      [N work units planned]
   Strategy:   [execution strategy]
-  ░░░░░░░░░░  GROUNDED
+  ░░░░░░░░░░  TAXIING
 ```
 
 ### Gate Panel
@@ -54,13 +54,13 @@ Render after each quality gate completes. Shows gate results inline.
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   test-runner       ██████████  LANDED
   code-reviewer     ██████░░░░  IN FLIGHT
-  security-auditor  ░░░░░░░░░░  GROUNDED
+  security-auditor  ░░░░░░░░░░  TAXIING
 ```
 
 Gate panel rules:
 - One row per gate agent.
 - Gate name left-aligned, gauge bar right of name, state label after bar.
-- Update rows as gates complete -- replace GROUNDED with LANDED or FAULT.
+- Update rows as gates complete -- replace TAXIING with LANDED or FAULT.
 <% } else if (context === 'ship') { -%>
 
 ### Departure Card
@@ -99,13 +99,13 @@ Render as a multi-row status overview. One row per worktree.
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   trees/TASK-001-auth       ██████████  LANDED
   trees/TASK-002-billing    ██████░░░░  IN FLIGHT
-  trees/TASK-003-notifs     ░░░░░░░░░░  GROUNDED
+  trees/TASK-003-notifs     ░░░░░░░░░░  TAXIING
   trees/TASK-004-search     ░░░░!!░░░░  FAULT
 ```
 
 Fleet dashboard rules:
 - One row per worktree. Path left-aligned, gauge bar and state right.
-- Sort: FAULT first, then IN FLIGHT, then GROUNDED, then LANDED.
+- Sort: FAULT first, then IN FLIGHT, then TAXIING, then LANDED.
 - If no worktrees exist, show a single line: `No active worktrees.`
 <% } else if (context === 'squadron') { -%>
 


### PR DESCRIPTION
## Summary
- Renames the `GROUNDED` gauge state to `TAXIING` across all source templates, generated commands, and tests
- GROUNDED carried a punitive connotation (grounded = in trouble); TAXIING is on-theme, implies forward motion toward the runway, and feels positive

## Changes
- `src/partials/visual-vocabulary.ejs` — gauge state definition and all context examples
- `src/commands/{takeoff,ship,status-worktrees,squadron}.ejs` — all references
- `scripts/{visual-vocabulary,contracts}.test.js` — updated assertions and constants
- 4 generated command files rebuilt

## Test plan
- [x] 515 tests passing, 0 failures
- [x] Zero `GROUNDED` occurrences remaining in src/ and commands/
- [x] 25 `TAXIING` occurrences across generated command files

Ref: reaper-c7k